### PR TITLE
Fix/remove general css rules from theme to extensions

### DIFF
--- a/scss/themes/platform/_common/base-theme.scss
+++ b/scss/themes/platform/_common/base-theme.scss
@@ -27,11 +27,6 @@ html {
         /// height of logo + margin must always be 64px to avoid jump effects
         #tao-main-logo {
         }
-
-        // scroll fix in iFrame for iOS
-        #qti-content {
-            -webkit-overflow-scrolling: touch;
-        }
     }
 }
 


### PR DESCRIPTION
Moved rule 
```
#qti-content {
            -webkit-overflow-scrolling: touch;
        }
```
into 
1. extension-tao-testqti https://github.com/oat-sa/extension-tao-testqti/
    file views/scss/inc/_test-layout.scss
2. extension-tao-testqti-previewer https://github.com/oat-sa/extension-tao-testqti-previewer/ 
   file views/js/previewer/provider/item/scss/inc/_previewer-layout.scss